### PR TITLE
Bug when parsing text including `class' or `id'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup,find_packages
 
 setup(name='pyjade',
-      version = '0.6.1',
+      version = '0.6.2',
       download_url = 'git@github.com:syrusakbary/pyjade.git',
       packages = find_packages(),
       author = 'Syrus Akbary',


### PR DESCRIPTION
It does not parse the text correctly when code includes `class' or`id'. For instance, the code:
    a(href="{{ url_for('browse_problem', problem_id=problem._id) }}")
is incorrectly parsed into:
    <a href="{{ url_for('browse_problem', problem_id=problem.get_id) }}"></a>
This problem is resolved after commenting several lines involving two regex. However I cannot understand what their uses are. Please take a look.
