### PR TITLE
Removing 'safe' argument to markdown

### DIFF
--- a/pyjade/ext/django/__init__.py
+++ b/pyjade/ext/django/__init__.py
@@ -9,7 +9,7 @@ class Compiler(_Compiler):
 
     def __init__(self, node, **options):
         super(Compiler, self).__init__(node, **options)
-        self.filters['markdown'] = lambda x, y: markdown(x, 'safe')
+        self.filters['markdown'] = lambda x, y: markdown(x)
 
     def visitCodeBlock(self,block):
         self.buffer('{%% block %s %%}'%block.name)


### PR DESCRIPTION
Not sure how you want to handle this, but 'safe' shouldn't be forced (my bad).  The Jade filters accept keyword arguments, but don't know how you want to translate them to a Django template tag function.
