### PR TITLE
Mixin block support (`+mixin` calls)

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -68,6 +68,7 @@ class Compiler(object):
         self.doctype = None
         self.terse = False
         self.xml = False
+        self.mixing = 0
         if 'doctype' in self.options: self.setDoctype(options['doctype'])
 
     def compile_top(self):

--- a/pyjade/lexer.py
+++ b/pyjade/lexer.py
@@ -25,11 +25,12 @@ class Lexer(object):
     RE_EXTENDS = re.compile(r'^extends? +([^\n]+)')
     RE_PREPEND = re.compile(r'^prepend +([^\n]+)')
     RE_APPEND = re.compile(r'^append +([^\n]+)')
-    RE_BLOCK = re.compile(r'^block +(?:(prepend|append) +)?([^\n]+)')
+    RE_BLOCK = re.compile(r'^block *(?:(prepend|append) +)?([^\n]*)')
     RE_YIELD = re.compile(r'^yield *')
     RE_INCLUDE = re.compile(r'^include +([^\n]+)')
     RE_ASSIGNMENT = re.compile(r'^(\w+) += *([^;\n]+)( *;? *)')
     RE_MIXIN = re.compile(r'^mixin +([-\w]+)(?: *\((.*)\))?')
+    RE_CALL = re.compile(r'^\+([-\w]+)(?: *\((.*)\))?')
     RE_CONDITIONAL = re.compile(r'^(?:- *)?(if|unless|else if|elif|else)\b([^\n]*)')
     # RE_WHILE = re.compile(r'^while +([^\n]+)')
     RE_EACH = re.compile(r'^(?:- *)?(?:each|for) +([\w, ]+) +in +([^\n]+)')
@@ -198,6 +199,14 @@ class Lexer(object):
         if captures:
             self.consume(len(captures[0]))
             tok = self.tok('mixin',captures[1])
+            tok.args = captures[2]
+            return tok
+
+    def call(self):
+        captures = regexec(self.RE_CALL,self.input)
+        if captures:
+            self.consume(len(captures[0]))
+            tok = self.tok('call',captures[1])
             tok.args = captures[2]
             return tok
 
@@ -401,6 +410,7 @@ class Lexer(object):
             or self.block() \
             or self.include() \
             or self.mixin() \
+            or self.call() \
             or self.conditional() \
             or self.each() \
             or self.assignment() \

--- a/pyjade/nodes.py
+++ b/pyjade/nodes.py
@@ -61,10 +61,11 @@ class Assignment(Node):
 		self.val = val
 
 class Mixin(Node):
-	def __init__(self,name, args, block=None):
+	def __init__(self, name, args, block, call):
 		self.name = name
 		self.args = args
 		self.block = block
+		self.call = call
 
 class Extends(Node):
 	def __init__(self,path):

--- a/pyjade/parser.py
+++ b/pyjade/parser.py
@@ -179,13 +179,24 @@ class Parser(object):
         path = self.expect('extends').val.strip('"\'')
         path = self.format_path(path)
         return nodes.Extends(path)
-    
+
+    def parseCall(self):
+        tok = self.expect('call')
+        name = tok.val
+        args = tok.args
+        if args is None:
+            args = ""
+        block = self.block() if 'indent' == self.peek().type else None
+        return nodes.Mixin(name,args,block,True)
+
     def parseMixin(self):
         tok = self.expect('mixin')
         name = tok.val
         args = tok.args
+        if args is None:
+            args = ""
         block = self.block() if 'indent' == self.peek().type else None
-        return nodes.Mixin(name,args,block)
+        return nodes.Mixin(name,args,block,block is None)
 
     def parseBlock(self):
         block = self.expect('block')

--- a/pyjade/testsuite/cases/mixin.blocks.html
+++ b/pyjade/testsuite/cases/mixin.blocks.html
@@ -1,0 +1,35 @@
+<html>
+  <body>
+<form method="GET" action="/search">
+  <input type="hidden" name="_csrf" value="hey"/>
+    <input type="text" name="query" placeholder="Search"/>
+    <input type="submit" value="Search"/>
+</form>
+  </body>
+</html>
+<html>
+  <body>
+<form method="POST" action="/search">
+  <input type="hidden" name="_csrf" value="hey"/>
+    <input type="text" name="query" placeholder="Search"/>
+    <input type="submit" value="Search"/>
+</form>
+  </body>
+</html>
+<html>
+  <body>
+<form method="POST" action="/search">
+  <input type="hidden" name="_csrf" value="hey"/>
+</form>
+  </body>
+</html>
+<div id="foo">
+<div id="bar">
+<p>one
+</p>
+<p>two
+</p>
+<p>three
+</p>
+</div>
+</div>

--- a/pyjade/testsuite/cases/mixin.blocks.jade
+++ b/pyjade/testsuite/cases/mixin.blocks.jade
@@ -1,0 +1,37 @@
+
+
+mixin form(method, action)
+  form(method=method, action=action)
+    csrf_token_from_somewhere = 'hey'
+    input(type='hidden', name='_csrf', value=csrf_token_from_somewhere)
+    block
+
+html
+  body
+    +form('GET', '/search')
+      input(type='text', name='query', placeholder='Search')
+      input(type='submit', value='Search')
+
+html
+  body
+    +form('POST', '/search')
+      input(type='text', name='query', placeholder='Search')
+      input(type='submit', value='Search')
+
+html
+  body
+    +form('POST', '/search')
+
+mixin bar()
+  #bar
+    block
+
+mixin foo()
+  #foo
+    +bar
+      block
+
++foo
+  p one
+  p two
+  p three

--- a/pyjade/testsuite/test_cases.py
+++ b/pyjade/testsuite/test_cases.py
@@ -143,7 +143,7 @@ def run_case(case,process):
         pass
 
 exclusions = {
-    'Html': set(['mixins', 'layout', 'unicode']),
+    'Html': set(['mixins', 'mixin.blocks', 'layout', 'unicode']),
     'Mako': set(['layout']),
     'Tornado': set(['layout']),
     'Jinja2': set(['layout']),


### PR DESCRIPTION
I've wanted to supply block content for mixins, and found that while Jade
allows this (using `+mixin` call notation), pyjade does not. So, here's a patch.

This should also resolve issue #46.

For reference, see original Jade commits visionmedia/jade@ae8e8b7d, visionmedia/jade@cf886ece and visionmedia/jade@8ec78bba.

Tests seem to pass fine, but I'm not sure about Jinja2 implementation, as
it contains a hack/workaround, because the following Jinja2 template failed to pass data. Don't know if that's Jinja's fault or just me misunderstanding something.

```
{% macro foo() %}
    <div id="foo">{% call bar %}{{ caller() }}{% endcall %}</div>
{% endmacro %}
```

I guess, my code should work fine for simple cases but some complex/bizarre nested mixin chains may misbehave.
