### PR TITLE
Remove soon-to-be-deprecated markdown filter from Django extension

### DIFF
--- a/pyjade/ext/django/__init__.py
+++ b/pyjade/ext/django/__init__.py
@@ -7,7 +7,6 @@ from pyjade.exceptions import CurrentlyNotSupported
 from pyjade.utils import process
 
 from django.conf import settings
-from django.contrib.markup.templatetags.markup import markdown
 
 class Compiler(_Compiler):
     autocloseCode = 'if,ifchanged,ifequal,ifnotequal,for,block,filter,autoescape,with,trans,blocktrans,spaceless,comment,cache,localize,compress'.split(',')
@@ -17,8 +16,8 @@ class Compiler(_Compiler):
         if settings.configured:
             options.update(getattr(settings,'PYJADE',{}))
         filters = options.get('filters',{})
-        if 'markdown' not in filters:
-            filters['markdown'] = lambda x, y: markdown(x)
+        if 'markdown' in filters:
+            raise CurrentlyNotSupported('markdown')
         self.filters.update(filters)
         super(Compiler, self).__init__(node, **options)
 


### PR DESCRIPTION
This commit removes the import of and use of the markdown filter from `django.contrib.markdown`. This is to ensure full Django 1.5-1.6 compatibility, and addresses half of issue #62.

Of course markdown support could be reimplemented in a commit to follow this one, but it should be handled with a 3rd party library to ensure full Django 1.5-6 compatibility.
