### PR TITLE
Fix 'makemessages' django command when jade templates have non-ASCII chars

### DIFF
--- a/pyjade/ext/django/compiler.py
+++ b/pyjade/ext/django/compiler.py
@@ -62,9 +62,11 @@ from django import template
 template.add_to_builtins('pyjade.ext.django.templatetags')
 
 from django.utils.translation import trans_real
+from django.utils.encoding import force_text
 
 def decorate_templatize(func):
     def templatize(src, origin=None):
+        src = force_text(src, settings.FILE_CHARSET)
         html = process(src,compiler=Compiler)
         return func(html, origin)
 


### PR DESCRIPTION
The `manage.py makemessages` django command was throwing an UnicodeDecodeError exception when there was jade templates with non ASCII chars:

```
Traceback (most recent call last):
  File ".../python-envs/hands-on/lib/python2.7/site-packages/django/core/management/base.py", line 240, in run_from_argv
    self.execute(*args, **options.__dict__)
  File ".../python-envs/hands-on/lib/python2.7/site-packages/django/core/management/base.py", line 283, in execute
    output = self.handle(*args, **options)
  File ".../python-envs/hands-on/lib/python2.7/site-packages/django/core/management/base.py", line 413, in handle
    return self.handle_noargs(**options)
  File ".../python-envs/hands-on/lib/python2.7/site-packages/django/core/management/commands/makemessages.py", line 264, in handle_noargs
    potfile = self.build_pot_file(localedir)
  File ".../python-envs/hands-on/lib/python2.7/site-packages/django/core/management/commands/makemessages.py", line 292, in build_pot_file
    f.process(self, potfile, self.domain, self.keep_pot)
  File ".../python-envs/hands-on/lib/python2.7/site-packages/django/core/management/commands/makemessages.py", line 74, in process
    content = templatize(src_data, orig_file[2:])
  File ".../python-envs/hands-on/lib/python2.7/site-packages/django/utils/translation/__init__.py", line 172, in templatize
    return _trans.templatize(src, origin)
  File ".../p/pyjade/pyjade/ext/django/compiler.py", line 68, in templatize
    html = process(src,compiler=Compiler)
  File ".../p/pyjade/pyjade/utils.py", line 225, in process
    return _compiler.compile().strip()
  File ".../p/pyjade/pyjade/compiler.py", line 83, in compile
    return unicode(u''.join(self.buf))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 28: ordinal not in range(128)
```

With the fix, the jade template source is converted to unicode before the processing and now it works.
