### PR TITLE
translated "- var..." syntax into jinja's "{% set... %}" syntax

### DIFF
--- a/pyjade/ext/jinja.py
+++ b/pyjade/ext/jinja.py
@@ -46,6 +46,9 @@ class Compiler(_Compiler):
         if code.buffer:
             val = code.val.lstrip()
             self.buf.append('{{%s%s}}'%(val,'|escape' if code.escape else ''))
+        elif code.val.lstrip()[:4] == 'var ':
+            val = code.val.lstrip()[4:]
+            self.buf.append('{%% set %s %%}'%val)
         else:
             self.buf.append('{%% %s %%}'%code.val)
 


### PR DESCRIPTION
example:

```
- var foo = 'bar'
```

preprocesses to:

```
{% set foo = 'bar' %}
```

What is strange is even though this gets hoisted up as a code node, the preprocessed output already replaced the 
`#{foo}` variable. In other words with the example above `{% set foo='bar' %}` will go on top, but any line such as `p hello, #{foo}` will be `<p>hello, bar</p>` before even getting to jinja.

Perhaps this is intentional by your design. Either way, this works more closely to the jade syntax.
