### PR TITLE
Get ./test.sh to run again by tweaking PYTHONPATH

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,4 @@
 #!/bin/sh
+SCRIPT_DIR=$( cd "$( dirname "$0" )" && pwd )
+export PYTHONPATH=$PYTHONPATH:$SCRIPT_DIR
 nosetests -w pyjade/testsuite/ -v


### PR DESCRIPTION
At one point I was able to do `./test.sh` and get back test results perfectly fine, but it appears my memory has made a fool of me, since all I got today was `ImportError: No module named pyjade`, in *sh (especially since pyjade is not installed globally on my machine). This included shell incantation appears to banish the import problems.
