### PR TITLE
Fix undefined attribute handling

### DIFF
--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -43,7 +43,7 @@ class HTMLCompiler(pyjade.compiler.Compiler):
         try:
             value = eval(value, self.global_context, self.local_context)
         except:
-            return ''
+            return None
         return value
 
     def _get_value(self, attr):

--- a/pyjade/ext/jinja.py
+++ b/pyjade/ext/jinja.py
@@ -1,12 +1,19 @@
 from jinja2.ext import Extension
 import os
+import pyjade.runtime
+
 from pyjade import Parser, Compiler as _Compiler
-from pyjade.runtime import attrs, iteration
+from pyjade.runtime import attrs as _attrs, iteration
 from jinja2.debug import fake_exc_info
+from jinja2.runtime import Undefined
 from pyjade.utils import process
 
 ATTRS_FUNC = '__pyjade_attrs'
 ITER_FUNC = '__pyjade_iter'
+
+def attrs(attrs, terse=False):
+    return _attrs(attrs, terse, Undefined)
+
 class Compiler(_Compiler):
 
     def visitCodeBlock(self,block):
@@ -26,7 +33,7 @@ class Compiler(_Compiler):
     def visitMixin(self,mixin):
         self.mixing += 1
         if not mixin.call:
-          self.buffer('{%% macro %s(%s) %%}'%(mixin.name,mixin.args)) 
+          self.buffer('{%% macro %s(%s) %%}'%(mixin.name,mixin.args))
           self.visitBlock(mixin.block)
           self.buffer('{% endmacro %}')
         elif mixin.block:
@@ -58,7 +65,7 @@ class Compiler(_Compiler):
               codeTag = code.val.strip().split(' ',1)[0]
               if codeTag in self.autocloseCode:
                   self.buf.append('{%% end%s %%}'%codeTag)
- 
+
     def visitEach(self,each):
         self.buf.append("{%% for %s in %s(%s,%d) %%}"%(','.join(each.keys),ITER_FUNC,each.obj,len(each.keys)))
         self.visit(each.block)
@@ -97,7 +104,7 @@ class PyJadeExtension(Extension):
         environment.globals[ITER_FUNC] = iteration
 
     def preprocess(self, source, name, filename=None):
-        if (not name or 
+        if (not name or
            (name and not os.path.splitext(name)[1] in self.file_extensions)):
             return source
         return process(source,filename=name,compiler=Compiler,**self.options)

--- a/pyjade/runtime.py
+++ b/pyjade/runtime.py
@@ -37,7 +37,7 @@ def escape(s):
         s = s
     else:
         s = str(s)
-    
+
     return (s
         .replace('&', '&amp;')
         .replace('>', '&gt;')
@@ -46,11 +46,13 @@ def escape(s):
         .replace('"', '&#34;')
     )
 
-def attrs (attrs=[],terse=False):
+def attrs (attrs=[],terse=False, undefined=None):
     buf = []
     if bool(attrs):
         buf.append('')
         for k,v in attrs:
+            if undefined is not None and isinstance(v, undefined):
+                continue
             if v!=None and (v!=False or type(v)!=bool):
                 if k=='class' and isinstance(v, (list, tuple)):
                     v = ' '.join(map(str,flatten(v)))

--- a/pyjade/testsuite/cases/attrs.html
+++ b/pyjade/testsuite/cases/attrs.html
@@ -2,4 +2,5 @@
 <select>
   <option value="foo" selected="selected">Foo</option>
   <option selected="selected" value="bar">Bar</option>
+  <option selected="selected">Qaz</option>
 </select>

--- a/pyjade/testsuite/cases/attrs.jade
+++ b/pyjade/testsuite/cases/attrs.jade
@@ -7,3 +7,4 @@ a(foo='((foo))', bar= (1 if 1 else 0 ))
 select
   option(value='foo', selected) Foo
   option(selected, value='bar') Bar
+  option(selected, value=missing) Qaz


### PR DESCRIPTION
As-per the jade documentation, attributes whose value is a variable
that is undefined, the attribute is now skipped for the outputs which
support it. Tornado and Django throw NameErrors whilst rendering so
this has no impact on them.
