### PR TITLE
Escape all #{} interpolated variables to match jade behavior

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -199,7 +199,7 @@ class Compiler(object):
         return self.RE_INTERPOLATE.sub(lambda matchobj:repl(matchobj.group(3)),attr)
 
     def interpolate(self,text):
-        return self._interpolate(text,lambda x:'%s%s%s' % (self.variable_start_string, x, self.variable_end_string))
+        return self._interpolate(text,lambda x:'%s%s|escape%s' % (self.variable_start_string, x, self.variable_end_string))
 
     def visitText(self,text):
         text = ''.join(text.nodes)

--- a/pyjade/ext/tornado/__init__.py
+++ b/pyjade/ext/tornado/__init__.py
@@ -26,6 +26,9 @@ class Compiler(_Compiler):
     #     else:
     #       self.buffer('{{%s(%s)}}'%(mixin.name,mixin.args))
 
+    def interpolate(self,text):
+        return self._interpolate(text,lambda x:'{{%s(%s)}}' % (ESCAPE_FUNC, x))
+
     def visitMixin(self,mixin):
         raise CurrentlyNotSupported('mixin')
 


### PR DESCRIPTION
According to jade docs, `!{html}` should be used for unescaped interpolation, whereas `#{html}` **should** escape: https://github.com/visionmedia/jade/blob/master/jade-language.md
