### PR TITLE
Don't escape #{} interpolated values that are in the content of a script tag

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -217,12 +217,16 @@ class Compiler(object):
         return self.RE_INTERPOLATE.sub(lambda matchobj:repl(matchobj.group(3)),
                                        attr)
 
-    def interpolate(self,text):
-        return self._interpolate(text, lambda x:'%s%s|escape%s' % (self.variable_start_string, x, self.variable_end_string))
+    def interpolate(self,text, escape=True):
+        if escape:
+            return self._interpolate(text,lambda x:'%s%s|escape%s' % (self.variable_start_string, x, self.variable_end_string))
+        return self._interpolate(text,lambda x:'%s%s%s' % (self.variable_start_string, x, self.variable_end_string))
+
 
     def visitText(self,text):
+        script = text.parent and text.parent.name == 'script'
         text = ''.join(text.nodes)
-        text = self.interpolate(text)
+        text = self.interpolate(text, script)
         self.buffer(text)
         if self.pp:
             self.buffer('\n')

--- a/pyjade/nodes.py
+++ b/pyjade/nodes.py
@@ -163,6 +163,8 @@ class Tag(Node):
 		return attrs+classes
 
 class Text(Node):
+	parent = None
+
 	def __init__(self, line=None):
 		self.nodes = []
 		if isinstance(line,six.string_types): self.append(line)

--- a/pyjade/parser.py
+++ b/pyjade/parser.py
@@ -15,7 +15,7 @@ class Parser(object):
         self.contexts = [self]
         self.extending = False
         self._spaces = None
-    
+
     def context(self,parser):
         if parser: self.context.append(parser)
         else: self.contexts.pop()
@@ -124,12 +124,12 @@ class Parser(object):
 
     def parseComment(self):
         tok = self.expect('comment')
-        
+
         if 'indent'==self.peek().type:
             node = nodes.BlockComment(tok.val, self.block(), tok.buffer)
         else:
             node = nodes.Comment(tok.val,tok.buffer)
-        
+
         node.line = self.line()
         return node
 
@@ -153,7 +153,7 @@ class Parser(object):
     def parseASTFilter(self):
         tok = self.expect('tag')
         attrs = self.accept('attrs')
-        
+
         self.expect(':')
         block = self.block()
 
@@ -216,9 +216,11 @@ class Parser(object):
         path = self.expect('include').val.strip()
         return nodes.Include(path)
 
-    def parseTextBlock(self):
+    def parseTextBlock(self, tag=None):
         text = nodes.Text()
         text.line = self.line()
+        if (tag):
+            text.parent == tag
         spaces = self.expect('indent').val
         if not self._spaces: self._spaces = spaces
         indent = ' '*(spaces-self._spaces)
@@ -303,7 +305,7 @@ class Parser(object):
             tag.block.append(self.parseExpr())
 
         while 'newline' == self.peek().type: self.advance()
-        
+
         tag.textOnly = tag.textOnly or tag.name in textOnly
 
         if 'script'== tag.name:
@@ -313,7 +315,7 @@ class Parser(object):
         if 'indent' == self.peek().type:
             if tag.textOnly:
                 self.lexer.pipeless = True
-                tag.block = self.parseTextBlock()
+                tag.block = self.parseTextBlock(tag)
                 self.lexer.pipeless = False
             else:
                 block = self.block()


### PR DESCRIPTION
It only makes sense to escape content that is in html tags that get rendered. Escaping values that are inserted in a script tag would break the javascript.
