### PR TITLE
Added assets autoclose code to support webassets

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -48,7 +48,7 @@ class Compiler(object):
       , 'br'
       , 'hr'
     ]
-    autocloseCode = 'if,for,block,filter,autoescape,with,trans,spaceless,comment,cache,macro,localize,compress'.split(',')
+    autocloseCode = 'if,for,block,filter,autoescape,with,trans,spaceless,comment,cache,macro,localize,compress,assets'.split(',')
 
     filters = {}
 

--- a/pyjade/ext/django/compiler.py
+++ b/pyjade/ext/django/compiler.py
@@ -9,7 +9,7 @@ from pyjade.utils import process
 from django.conf import settings
 
 class Compiler(_Compiler):
-    autocloseCode = 'if,ifchanged,ifequal,ifnotequal,for,block,filter,autoescape,with,trans,blocktrans,spaceless,comment,cache,localize,compress,verbatim'.split(',')
+    autocloseCode = 'if,ifchanged,ifequal,ifnotequal,for,block,filter,autoescape,with,trans,blocktrans,spaceless,comment,cache,localize,compress,assets,verbatim'.split(',')
     useRuntime = True
 
     def __init__(self, node, **options):


### PR DESCRIPTION
Hello there,

I've added "assets" to the autoclose list to support [webassets](https://github.com/miracle2k/webassets) which has extensions for...
- **Flask**: [Flask-Assets](https://github.com/miracle2k/flask-assets)
- **Django**: [Django-Assets](https://github.com/miracle2k/django-assets)

It is similar to Django compressor and is the main asset manager for Flask.  Would be great to have this included if you don't mind :smile: 

Thanks
Fotis
