### PR TITLE
Add escape=True param to interpolate() of Compiler subclasses

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -217,7 +217,7 @@ class Compiler(object):
         return self.RE_INTERPOLATE.sub(lambda matchobj:repl(matchobj.group(3)),
                                        attr)
 
-    def interpolate(self,text, escape=True):
+    def interpolate(self, text, escape=True):
         if escape:
             return self._interpolate(text,lambda x:'%s%s|escape%s' % (self.variable_start_string, x, self.variable_end_string))
         return self._interpolate(text,lambda x:'%s%s%s' % (self.variable_start_string, x, self.variable_end_string))

--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -67,7 +67,7 @@ class HTMLCompiler(pyjade.compiler.Compiler):
                 self.visitBlock(mixin.block)
         return _mixin
 
-    def interpolate(self,text):
+    def interpolate(self, text, escape=True):
         return self._interpolate(text, lambda x: str(self._do_eval(x)))
 
     def visitInclude(self, node):

--- a/pyjade/ext/mako.py
+++ b/pyjade/ext/mako.py
@@ -15,7 +15,7 @@ class Compiler(_Compiler):
     def compile_top(self):
         return '# -*- coding: utf-8 -*-\n<%%! from pyjade.runtime import attrs as %s, iteration as %s\nfrom mako.runtime import Undefined %%>' % (ATTRS_FUNC,ITER_FUNC)
 
-    def interpolate(self,text):
+    def interpolate(self, text, escape=True):
         return self._interpolate(text,lambda x:'${%s}'%x)
 
     def visitCodeBlock(self,block):

--- a/pyjade/ext/tornado/__init__.py
+++ b/pyjade/ext/tornado/__init__.py
@@ -26,7 +26,7 @@ class Compiler(_Compiler):
     #     else:
     #       self.buffer('{{%s(%s)}}'%(mixin.name,mixin.args))
 
-    def interpolate(self,text):
+    def interpolate(self, text, escape=True):
         return self._interpolate(text,lambda x:'{{%s(%s)}}' % (ESCAPE_FUNC, x))
 
     def visitMixin(self,mixin):

--- a/pyjade/ext/underscore.py
+++ b/pyjade/ext/underscore.py
@@ -108,5 +108,5 @@ class Compiler(_Compiler):
               self.visitConditional(next)
         if conditional.type in ['if','unless']: self.buf.append('\n<% } %>\n')
         
-    def interpolate(self,text):
+    def interpolate(self, text, escape=True):
         return self._interpolate(text,lambda x:'<%%= %s %%>'%x)


### PR DESCRIPTION
Since fc52632ea7b4aae5016273e4621b18a15042970e added an `escape` parameter to `Compiler.interpolate`, several tests were failing since the various subclasses of `Compiler` were missing `escape` from their method signatures. This just adds `escape=True` to those signatures to match.
