### PR TITLE
improve include support for mako

### DIFF
--- a/pyjade/ext/mako.py
+++ b/pyjade/ext/mako.py
@@ -52,6 +52,7 @@ class Compiler(_Compiler):
     def visitInclude(self,node):
         path = self.format_path(node.path)
         self.buffer('<%%include file="%s"/>'%(path))
+        self.buffer('<%%namespace file="%s" import="*"/>'%(path))
 
 
     def visitConditional(self,conditional):


### PR DESCRIPTION
In upstream jade, when you include a file you also receive all of that
file's mixins. This is possible in Mako by using the namespace tag and
importing everything.
