### PR TITLE
Enhancement for mixin

### DIFF
--- a/pyjade/lexer.py
+++ b/pyjade/lexer.py
@@ -38,7 +38,7 @@ class Lexer(object):
     RE_INCLUDE = re.compile(r'^include +([^\n]+)')
     RE_ASSIGNMENT = re.compile(r'^(-\s+var\s+)?(\w+) += *([^;\n]+)( *;? *)')
     RE_MIXIN = re.compile(r'^mixin +([-\w]+)(?: *\((.*)\))?')
-    RE_CALL = re.compile(r'^\+([-\w]+)(?: *\((.*)\))?')
+    RE_CALL = re.compile(r'^\+\s*([-.\w]+)(?: *\((.*)\))?')
     RE_CONDITIONAL = re.compile(r'^(?:- *)?(if|unless|else if|elif|else)\b([^\n]*)')
     RE_BLANK = re.compile(r'^\n *\n')
     # RE_WHILE = re.compile(r'^while +([^\n]+)')


### PR DESCRIPTION
The `=` operator supports whitespace after it

```
= var
```

but the call operator `+` does not

```
+ mixin
```

-> error

It would be visually better if the `+` also allows whitespace after it to align it with `=` before it, especially if using 2 space indent.

```
= var
+ mixin
  block
```

instead of

```
= var
+mixin
  block
```

Also enable support for module function call as mixin so we can do this (using jinja)

mymacro.html:

``` jinja
{% macro wrap() %}
<div>{{ caller() }}</div>
{% endmacro %}
```

template.jade

``` jade
- import 'mymacro.html' as mymacro
+ mymacro.wrap
  | content
```
