### PR TITLE
Add unescaped interpolation to the jinja compiler

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -234,9 +234,8 @@ class Compiler(object):
         return self.RE_INTERPOLATE.sub(repl, text)
 
     def visitText(self,text):
-        script = text.parent and text.parent.name == 'script'
         text = ''.join(text.nodes)
-        text = self.interpolate(text, script)
+        text = self.interpolate(text)
         self.buffer(text)
         if self.pp:
             self.buffer('\n')

--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -217,11 +217,21 @@ class Compiler(object):
         return self.RE_INTERPOLATE.sub(lambda matchobj:repl(matchobj.group(3)),
                                        attr)
 
-    def interpolate(self, text, escape=True):
-        if escape:
-            return self._interpolate(text,lambda x:'%s%s|escape%s' % (self.variable_start_string, x, self.variable_end_string))
-        return self._interpolate(text,lambda x:'%s%s%s' % (self.variable_start_string, x, self.variable_end_string))
+    def interpolate(self, text, escape=None):
+        def repl(matchobj):
+            if escape is None:
+                if matchobj.group(2) == '!':
+                    filter_string = ''
+                else:
+                    filter_string = '|escape'
+            elif escape is True:
+                filter_string = '|escape'
+            elif escape is False:
+                filter_string = ''
 
+            return self.variable_start_string + matchobj.group(3) + \
+                filter_string + self.variable_end_string
+        return self.RE_INTERPOLATE.sub(repl, text)
 
     def visitText(self,text):
         script = text.parent and text.parent.name == 'script'


### PR DESCRIPTION
This syntax now does what it should do in the jinja compiler:
```
!{<i>blaa</i>}
```
it compiles to: *blaa*
This is all according to this spec: http://jade-lang.com/reference/code/ (see the bottom of the page)

The other compilers are not supported since they all work differently and I'm not sure how to make it more general, also I don't use the other compilers.