### PR TITLE
Fix TypeError in python3

### DIFF
--- a/pyjade/convert.py
+++ b/pyjade/convert.py
@@ -50,14 +50,14 @@ def convert_file():
         if len(args) >= 1:
             template = codecs.open(args[0], 'r', encoding='utf-8').read()
         else:
-            template = codecs.getreader('utf-8')(sys.stdin).read()
+            template = codecs.getreader('utf-8')(getattr(sys.stdin, 'buffer', sys.stdin)).read()
         output = process(template, compiler=available_compilers[compiler],
                          staticAttrs=True, extension=extension)
         if file_output:
             outfile = codecs.open(file_output, 'w', encoding='utf-8')
             outfile.write(output)
         else:
-            codecs.getwriter('utf-8')(sys.stdout).write(output)
+            codecs.getwriter('utf-8')(getattr(sys.stdout, 'buffer', sys.stdout)).write(output)
     else:
         raise Exception('You must have %s installed!' % compiler)
 


### PR DESCRIPTION

* output to stdout in python3  
`pyjade -c tornado index.jade`  
get this error 
```
WARNING:root:No module named 'django'
Traceback (most recent call last):
  File "/home/yukirin/venv_local/bin/pyjade", line 9, in <module>
    load_entry_point('pyjade==3.0.0', 'console_scripts', 'pyjade')()
  File "/home/yukirin/venv_local/lib/python3.4/site-packages/pyjade-3.0.0-py3.4.egg/pyjade/convert.py", line 60, in convert_file
  File "/usr/lib/python3.4/codecs.py", line 369, in write
    self.stream.write(data)
TypeError: must be str, not bytes
```
* input from stdin in python3  
`pyjade -c tornado < index.jade`  
get this error 
```
WARNING:root:No module named 'django'
Traceback (most recent call last):
  File "/home/yukirin/venv_local/bin/pyjade", line 9, in <module>
    load_entry_point('pyjade==3.0.0', 'console_scripts', 'pyjade')()
  File "/home/yukirin/venv_local/lib/python3.4/site-packages/pyjade-3.0.0-py3.4.egg/pyjade/convert.py", line 53, in convert_file
  File "/usr/lib/python3.4/codecs.py", line 490, in read
    data = self.bytebuffer + newdata
TypeError: can't concat bytes to str
```
 with the Fix, change to use stdout(stdin).buffer in python3