### PR TITLE
fix for django makemessage command

### DIFF
--- a/pyjade/ext/django/compiler.py
+++ b/pyjade/ext/django/compiler.py
@@ -72,7 +72,10 @@ except ImportError:
 def decorate_templatize(func):
     def templatize(src, origin=None):
         src = to_text(src, settings.FILE_CHARSET)
-        html = process(src,compiler=Compiler)
+        if origin.endswith(".jade"):
+            html = process(src,compiler=Compiler)
+        else:
+            html = src
         return func(html, origin)
 
     return templatize


### PR DESCRIPTION
pyjade try to compile all files in various template dirs in
makemessages command.
Relates to #37 
Solution: Force it only compile jade file.