### PR TITLE
Django 1.8 requires settings to be configured

### DIFF
--- a/pyjade/ext/django/loader.py
+++ b/pyjade/ext/django/loader.py
@@ -5,6 +5,10 @@ from django.template.base import TemplateDoesNotExist, Template
 from django.template.loader import BaseLoader
 try:
     from django.template.engine import Engine
+    from django.conf import settings
+    from django.core.exceptions import ImproperlyConfigured
+    try: settings.TEMPLATES
+    except ImproperlyConfigured: settings.configure()
     make_origin = Engine.get_default().make_origin
     find_template_loader = Engine.get_default().find_template_loader
 except ImportError: # Django < 1.8


### PR DESCRIPTION
fixes another Django 1.8 incompatibility:

    File ".../pyjade/ext/django/__init__.py", line 3, in <module>
    from .loader import Loader
    File ".../pyjade/ext/django/loader.py", line 8, in <module>
    make_origin = Engine.get_default().make_origin
    ...
    django.core.exceptions.ImproperlyConfigured: Requested setting TEMPLATES, but settings are not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call settings.configure() before accessing settings.
