### PR TITLE
added ability to use quotes in include tag

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -258,7 +258,7 @@ class Compiler(object):
 
 
     def format_path(self,path):
-        path = path.strip(" '\"")
+        path = path.strip("'\"")
         has_extension = os.path.basename(path).find('.') > -1
         if not has_extension:
             path += self.extension

--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -258,6 +258,7 @@ class Compiler(object):
 
 
     def format_path(self,path):
+        path = path.strip(" '\"")
         has_extension = os.path.basename(path).find('.') > -1
         if not has_extension:
             path += self.extension


### PR DESCRIPTION
if you have filenames with spaces or wish to use additional django-specific include flags, like "with foo=bar", you need to be able to surround the filename with double or single quotes.
This commit simply strips quotes from any path passed to the include or extends tags.
