### PR TITLE
Allow explicitly self-closed tags

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -177,6 +177,13 @@ class Compiler(object):
             self.instring = False
 
         closed = name in self.selfClosing and not self.xml
+        if tag.text:
+            t = tag.text.nodes[0]
+            if t.startswith(u'/'):
+                if len(t) > 1:
+                    raise Exception('%s is self closing and should not have content.' % name)
+                closed = True
+
         self.buffer('<%s' % name)
         self.visitAttributes(tag.attrs)
         self.buffer('/>' if not self.terse and closed else '>')

--- a/pyjade/testsuite/cases/selfclosing.html
+++ b/pyjade/testsuite/cases/selfclosing.html
@@ -1,0 +1,3 @@
+<foo/>
+<foo>/</foo>
+<div blah="x"/>

--- a/pyjade/testsuite/cases/selfclosing.jade
+++ b/pyjade/testsuite/cases/selfclosing.jade
@@ -1,0 +1,5 @@
+foo/
+
+foo /
+
+div(blah="x")/


### PR DESCRIPTION
Resolves #186. Behaves the same way as Jade(JS). Includes passing tests.