### PR TITLE
Fixed text only handling

### DIFF
--- a/pyjade/parser.py
+++ b/pyjade/parser.py
@@ -3,8 +3,6 @@ from .lexer import Lexer
 from . import nodes
 import six
 
-textOnly = ('script','style')
-
 class Parser(object):
     def __init__(self,str,filename=None,**options):
         self.input = str
@@ -324,12 +322,6 @@ class Parser(object):
         elif 'text'==t: tag.text = self.parseText()
 
         while 'newline' == self.peek().type: self.advance()
-
-        tag.textOnly = tag.textOnly or tag.name in textOnly
-
-        if 'script'== tag.name:
-            type = tag.getAttribute('type')
-            if not dot and type and 'text/javascript' !=type.strip('"\''): tag.textOnly = False
 
         if 'indent' == self.peek().type:
             if tag.textOnly:

--- a/pyjade/testsuite/cases/script.whitespace.jade
+++ b/pyjade/testsuite/cases/script.whitespace.jade
@@ -1,4 +1,4 @@
-script
+script.
   if (foo) {
     
     bar();

--- a/pyjade/testsuite/cases/scripts.jade
+++ b/pyjade/testsuite/cases/scripts.jade
@@ -1,4 +1,4 @@
-script
+script.
   if (foo) {
     bar();
   }


### PR DESCRIPTION
As mentioned in #173, pyjade is being inaccurate to what Jade's normal implementations are. This PR remedies block handling to be more inline with Jade's definition.

In this PR:

- Removed implicit assumptions that script/style are text-only (Jade doesn't do this)
- Updated test suite to be more inline with Jade test suite