### PR TITLE
Add html5 self-closing / empty-element tags

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -36,6 +36,7 @@ class Compiler(object):
       , 'sub'
       , 'sup'
       , 'textarea'
+      , 'wbr'
     ]
     selfClosing = [
         'meta'
@@ -47,6 +48,12 @@ class Compiler(object):
       , 'col'
       , 'br'
       , 'hr'
+      , 'embed'
+      , 'menuitem'
+      , 'param'
+      , 'source'
+      , 'track'
+      , 'wbr'
     ]
     autocloseCode = 'if,for,block,filter,autoescape,with,trans,spaceless,comment,cache,macro,localize,compress,raw'.split(',')
 


### PR DESCRIPTION
HTML5 adds some more empty-element tags, such as  [`<embed>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed).

This commit makes pyjade consistent with jade for these tags (see [jade's void-elements list](https://github.com/jadejs/void-elements/blob/master/index.js)).

``` jade
//-
  jade source    pyjade, previously     pyjade, now

embed            <embed></embed>        <embed/>

doctype html     <!DOCTYPE html>        <!DOCTYPE html>
embed            <embed></embed>        <embed>

p                <p></p>                <p></p>
```

The existing test case `html5.jade` covers this, I think, because it has `<input>`s, which were already in the self-closing list.
