### PR TITLE
Include files verbatim if they have an extension that is not .jade

### DIFF
--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -72,19 +72,19 @@ class Compiler(pyjade.compiler.Compiler):
         return self._interpolate(text, lambda x: str(self._do_eval(x)))
 
     def visitInclude(self, node):
-        if os.path.exists(node.path):
-            src = open(node.path, 'r').read()
-        elif os.path.exists("%s.jade" % node.path):
-            src = open("%s.jade" % node.path, 'r').read()
-        else:
-            raise Exception("Include path '%s' doesn't exist" % node.path)
+        path = self.format_path(node.path)
 
-        if node.path.endswith(u'.jade') or u'.' not in node.path:
+        if os.path.exists(path):
+            src = open(path, 'r').read()
+        else:
+            raise Exception("Include path '%s' doesn't exist" % path)
+
+        if path.endswith('.jade'):
             parser = pyjade.parser.Parser(src)
             block = parser.parse()
             self.visit(block)
         else:
-            if src.endswith(u'\n'):
+            if src.endswith('\n'):
                 src = src[:-1]
             self.buffer(src)
 

--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -77,7 +77,7 @@ class Compiler(pyjade.compiler.Compiler):
         elif os.path.exists("%s.jade" % node.path):
             src = open("%s.jade" % node.path, 'r').read()
         else:
-            raise Exception("Include path doesn't exists")
+            raise Exception("Include path '%s' doesn't exist" % node.path)
 
         parser = pyjade.parser.Parser(src)
         block = parser.parse()

--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -79,9 +79,14 @@ class Compiler(pyjade.compiler.Compiler):
         else:
             raise Exception("Include path '%s' doesn't exist" % node.path)
 
-        parser = pyjade.parser.Parser(src)
-        block = parser.parse()
-        self.visit(block)
+        if node.path.endswith(u'.jade') or u'.' not in node.path:
+            parser = pyjade.parser.Parser(src)
+            block = parser.parse()
+            self.visit(block)
+        else:
+            if src.endswith(u'\n'):
+                src = src[:-1]
+            self.buffer(src)
 
     def visitExtends(self, node):
         raise pyjade.exceptions.CurrentlyNotSupported()

--- a/pyjade/testsuite/cases/include-plain-text-css.css
+++ b/pyjade/testsuite/cases/include-plain-text-css.css
@@ -1,0 +1,2 @@
+/* include-plain-text-css.css */
+h1 { color: red; }

--- a/pyjade/testsuite/cases/include-plain-text-script.js
+++ b/pyjade/testsuite/cases/include-plain-text-script.js
@@ -1,0 +1,2 @@
+// include-plain-text-script.js
+console.log('You are awesome');

--- a/pyjade/testsuite/cases/include-plain-text.html
+++ b/pyjade/testsuite/cases/include-plain-text.html
@@ -1,0 +1,8 @@
+<head>
+  <style>/* include-plain-text-css.css */
+h1 { color: red; }
+  </style>
+</head>
+<script>// include-plain-text-script.js
+console.log('You are awesome');
+</script>

--- a/pyjade/testsuite/cases/include-plain-text.jade
+++ b/pyjade/testsuite/cases/include-plain-text.jade
@@ -1,0 +1,6 @@
+head
+    style
+        include include-plain-text-css.css
+
+script
+    include include-plain-text-script.js


### PR DESCRIPTION
Does what it says on the tin.

This brings pyjade's HTML compiler into compliance with [Jade's behaviour](http://jade-lang.com/reference/includes/) for including "plain text", which Jade defines as anything that has an extension that is not `.jade`. Includes that do end in `.jade` or have no extension (after path processing -- see below) are (still) parsed as Jade.

This PR does not affect the django compiler, which already had this behaviour.

No test cases needed to be changed, only new ones added -- although anyone who wants to test this on a larger corpus would be very welcome.
