### PR TITLE
Micro speedups: operator, {}

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -265,7 +265,7 @@ class Compiler(object):
 
 
     def format_path(self,path):
-        has_extension = os.path.basename(path).find('.') > -1
+        has_extension = '.' in os.path.basename(path)
         if not has_extension:
             path += self.extension
         return path

--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -6,6 +6,7 @@ import pyjade
 from pyjade.runtime import is_mapping, iteration, escape
 import six
 import os
+import operator 
 
 def process_param(key, value, terse=False):
     if terse:
@@ -17,9 +18,9 @@ def process_param(key, value, terse=False):
 
 
 TYPE_CODE = {
-    'if': lambda v: bool(v),
-    'unless': lambda v: not bool(v),
-    'elsif': lambda v: bool(v),
+    'if': operator.truth,
+    'unless': operator.not_,
+    'elsif': operator.truth,
     'else': lambda v: True}
 
 

--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -35,9 +35,9 @@ def local_context_manager(compiler, local_context):
 
 
 class Compiler(pyjade.compiler.Compiler):
-    global_context = dict()
-    local_context = dict()
-    mixins = dict()
+    global_context = {}
+    local_context = {}
+    mixins = {}
     useRuntime = True
     def _do_eval(self, value):
         if isinstance(value, six.string_types):
@@ -123,7 +123,7 @@ class Compiler(pyjade.compiler.Compiler):
     def visitEach(self, each):
         obj = iteration(self._do_eval(each.obj), len(each.keys))
         for item in obj:
-            local_context = dict()
+            local_context = {}
             if len(each.keys) > 1:
                 for (key, value) in zip(each.keys, item):
                     local_context[key] = value


### PR DESCRIPTION
`operator` exists and is 4-5x faster than wrapping language builtins in `lambda`, if you do silly microtests or render thousands of conditionals in HTML templates.

This breaks nothing, should be slightly faster, and is slightly cleaner than before, I think.