### PR TITLE
Update readme for Django 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,37 @@ with the pyjade compiler.
 Django
 ------
 
+**For Django 1.8 and above:**
+
+In `settings.py`, add a `loader` to `TEMPLATES` like so:
+
+```python
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+                'django.core.context_processors.request'
+            ],
+            'loaders': [
+                # PyJade part:   ##############################
+                ('pyjade.ext.django.Loader', (
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                ))
+            ]
+        },
+    },
+]
+```
+
+**Or, in Django 1.7 or earlier:**
+
 In `settings.py`, modify `TEMPLATE_LOADERS` like:
 
 ```python


### PR DESCRIPTION
In Django 1.8, the syntax for template loaders [has changed](https://docs.djangoproject.com/en/1.8/releases/1.8/#template-related-settings).

This updates the readme based on [this issue](https://github.com/syrusakbary/pyjade/issues/185) to address that.