### PR TITLE
don't html_escape dynamic mako attributes

### DIFF
--- a/pyjade/ext/mako.py
+++ b/pyjade/ext/mako.py
@@ -97,7 +97,7 @@ class Compiler(_Compiler):
         self.buf.append('\\\n% endfor\n')
 
     def attributes(self,attrs):
-        return "${%s(%s, undefined=Undefined)}"%(ATTRS_FUNC,attrs)
+        return "${%s(%s, undefined=Undefined) | n}"%(ATTRS_FUNC,attrs)
 
 
 


### PR DESCRIPTION
This is a fix for the problem that variable url attributes are html_escaped when using pyjade as mako preprocessor in combination with pyramid.

A similar issue was raised before for static attributes: https://github.com/syrusakbary/pyjade/issues/12 

The following code, when rendered with the current code 
```jade
a(href="http://www.some_url.com")
a(href=dynamic_url)
```
rendered with
```python
@view_config(route_name='test',
             renderer='test.jade')
def test():
    return {'dynamic_url': 'http://www.some_url.com'}
```
returns the following html:
```html
<a href="http://www.some_url.com"></a>
<a href=&#34;http://www.some_url.com&#34;></a>
```

with this pull request, the expected html is returned:
```html
<a href="http://www.some_url.com"></a>
<a href="http://www.some_url.com"></a>
```