### PR TITLE
Update pyjade to work on Django 1.9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ with the pyjade compiler.
 Django
 ------
 
-**For Django 1.8 and above:**
+**For Django 1.9**
 
 In `settings.py`, add a `loader` to `TEMPLATES` like so:
 
@@ -82,7 +82,37 @@ TEMPLATES = [
                     'django.template.loaders.filesystem.Loader',
                     'django.template.loaders.app_directories.Loader',
                 ))
-            ]
+            ],
+            'builtins': ['pyjade.ext.django.templatetags'],
+        },
+    },
+]
+```
+
+**For Django 1.8**
+
+In `settings.py`, add a `loader` to `TEMPLATES` like so:
+
+```python
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+                'django.core.context_processors.request'
+            ],
+            'loaders': [
+                # PyJade part:   ##############################
+                ('pyjade.ext.django.Loader', (
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                ))
+            ],
         },
     },
 ]

--- a/README.rst
+++ b/README.rst
@@ -31,16 +31,33 @@ with the pyjade compiler.
 Django
 ------
 
-In `settings.py`, modify `TEMPLATE_LOADERS` like
+In `settings.py`, add a `loader` to `TEMPLATES` like so:
 
 .. code:: python
 
-    TEMPLATE_LOADERS = (
-        ('pyjade.ext.django.Loader',(
-            'django.template.loaders.filesystem.Loader',
-            'django.template.loaders.app_directories.Loader',
-        )),
-    )
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                    'django.core.context_processors.request'
+                ],
+                'loaders': [
+                    # PyJade part:   ##############################
+                    ('pyjade.ext.django.Loader', (
+                        'django.template.loaders.filesystem.Loader',
+                        'django.template.loaders.app_directories.Loader',
+                    ))
+                ],
+                'builtins': ['pyjade.ext.django.templatetags'],  # Remove this line for Django 1.8
+            },
+        },
+    ]
 
 
 Jinja2

--- a/pyjade/ext/django/compiler.py
+++ b/pyjade/ext/django/compiler.py
@@ -60,10 +60,16 @@ class Compiler(_Compiler):
 
 
 try:
-    from django.template.base import add_to_builtins
-except ImportError: # Django < 1.8
-    from django.template import add_to_builtins
-add_to_builtins('pyjade.ext.django.templatetags')
+    try:
+        from django.template.base import add_to_builtins
+    except ImportError: # Django < 1.8
+        from django.template import add_to_builtins
+    add_to_builtins('pyjade.ext.django.templatetags')
+except ImportError:
+    # Django 1.9 removed add_to_builtins and instead
+    # provides a setting to specify builtins:
+    # TEMPLATES['OPTIONS']['builtins'] = ['pyjade.ext.django.templatetags']
+    pass
 
 from django.utils.translation import trans_real
 


### PR DESCRIPTION
Django 1.9 changed the private template APIs quite a bit. `make_origin`
was removed and things were moved between modules. This commit addresses
the changes by introducing import fallbacks for the changes and a shim
for `make_origin` change. Also updates tests Django extension.

Prepared by @arnists and @frgtn during [DjangoUnderTheHood](http://djangounderthehood.com) sprint.