### PR TITLE
Honor Jinja's block_start/end_string options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/*
 *.DS_Store
 *.sublime-*
 .idea
+.eggs

--- a/pyjade/convert.py
+++ b/pyjade/convert.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import sys
 import logging
 import codecs
-from optparse import OptionParser
+import argparse
 from pyjade.utils import process
 import os
 
@@ -11,63 +11,68 @@ def convert_file():
     available_compilers = {}
     for i in support_compilers_list:
         try:
+            if i == "django":
+                from django.conf import settings
+                settings.configure()
+
             compiler_class = __import__('pyjade.ext.%s' % i, fromlist=['pyjade']).Compiler
         except ImportError as e:
             logging.warning(e)
         else:
             available_compilers[i] = compiler_class
 
-    usage = "usage: %prog [options] [file [output]]"
-    parser = OptionParser(usage)
-    parser.add_option("-o", "--output", dest="output",
-                    help="Write output to FILE", metavar="FILE")
+    usage = "usage: %(prog)s [options] [input [output]]"
+    parser = argparse.ArgumentParser(usage=usage)
+
+    parser.add_argument("-o", "--output", help="write output to FILE", metavar="FILE")
+
     # use a default compiler here to sidestep making a particular
     # compiler absolutely necessary (ex. django)
     default_compiler = sorted(available_compilers.keys())[0]
-    parser.add_option("-c", "--compiler", dest="compiler",
+    parser.add_argument("-c", "--compiler",
                     choices=list(available_compilers.keys()),
                     default=default_compiler,
-                    type="choice",
-                    help=("COMPILER must be one of %s, default is %s" %
-                          (', '.join(list(available_compilers.keys())), default_compiler)))
-    parser.add_option("-e", "--ext", dest="extension",
-                      help="Set import/extends default file extension",
+                    metavar="COMPILER",
+                    help="template compiler, %s by default; supported compilers are: %s" % (default_compiler, ", ".join(available_compilers.keys())))
+    parser.add_argument("-e", "--ext", dest="extension",
+                      help="set import/extends default file extension",
                       metavar="FILE")
-    parser.add_option("--block_start_string", default="{%", help="valid for jinja compiler only, defaut is '{%'")
-    parser.add_option("--block_end_string", default="%}", help="valid for jinja compiler only, defaut is '%}'")
-    parser.add_option("--variable_start_string", default="{{", help="valid for jinja compiler only, defaut is '{{'")
-    parser.add_option("--variable_end_string", default="}}", help="valid for jinja compiler only, defaut is '}}'")
+    parser.add_argument("--block_start_string", metavar="STRING", default="{%", help="valid for jinja compiler only, defaut is '{%%'")
+    parser.add_argument("--block_end_string", metavar="STRING", default="%}", help="valid for jinja compiler only, defaut is '%%}'")
+    parser.add_argument("--variable_start_string", metavar="STRING", default="{{", help="valid for jinja compiler only, defaut is '{{'")
+    parser.add_argument("--variable_end_string", metavar="STRING", default="}}", help="valid for jinja compiler only, defaut is '}}'")
+    parser.add_argument("input", nargs="?")
+    parser.add_argument("output", nargs="?", default=argparse.SUPPRESS)
 
-    options, args = parser.parse_args()
+    args = parser.parse_args()
 
-    file_output = options.output or (args[1] if len(args) > 1 else None)
-    compiler = options.compiler
+    compiler = args.compiler
 
-    if compiler != "jinja":
-        options.pop("block_start_string", None)
-        options.pop("block_end_string", None)
-        options.pop("variable_start_string", None)
-        options.pop("variable_end_string", None)
-
-    if options.extension:
-        extension = '.%s' % options.extension
-    elif options.output:
-        extension = os.path.splitext(options.output)[1]
+    if args.extension:
+        extension = '.%s' % args.extension
+    elif args.output:
+        extension = os.path.splitext(args.output)[1]
     else:
         extension = None
 
     if compiler in available_compilers:
         import six
-        if len(args) >= 1:
-            template = codecs.open(args[0], 'r', encoding='utf-8').read()
+        if args.input:
+            template = codecs.open(args.input, 'r', encoding='utf-8').read()
         elif six.PY3:
             template = sys.stdin.read()
         else:
             template = codecs.getreader('utf-8')(sys.stdin).read()
+
         output = process(template, compiler=available_compilers[compiler],
-                         staticAttrs=True, extension=extension)
-        if file_output:
-            outfile = codecs.open(file_output, 'w', encoding='utf-8')
+                         staticAttrs=True, extension=extension,
+                         block_start_string=args.block_start_string,
+                         block_end_string=args.block_end_string,
+                         variable_start_string=args.variable_start_string,
+                         variable_end_string=args.variable_end_string)
+
+        if args.output:
+            outfile = codecs.open(args.output, 'w', encoding='utf-8')
             outfile.write(output)
         elif six.PY3:
             sys.stdout.write(output)

--- a/pyjade/convert.py
+++ b/pyjade/convert.py
@@ -33,11 +33,21 @@ def convert_file():
     parser.add_option("-e", "--ext", dest="extension",
                       help="Set import/extends default file extension",
                       metavar="FILE")
+    parser.add_option("--block_start_string", default="{%", help="valid for jinja compiler only, defaut is '{%'")
+    parser.add_option("--block_end_string", default="%}", help="valid for jinja compiler only, defaut is '%}'")
+    parser.add_option("--variable_start_string", default="{{", help="valid for jinja compiler only, defaut is '{{'")
+    parser.add_option("--variable_end_string", default="}}", help="valid for jinja compiler only, defaut is '}}'")
 
     options, args = parser.parse_args()
 
     file_output = options.output or (args[1] if len(args) > 1 else None)
     compiler = options.compiler
+
+    if compiler != "jinja":
+        options.pop("block_start_string", None)
+        options.pop("block_end_string", None)
+        options.pop("variable_start_string", None)
+        options.pop("variable_end_string", None)
 
     if options.extension:
         extension = '.%s' % options.extension

--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -78,7 +78,7 @@ class Compiler(pyjade.compiler.Compiler):
         elif os.path.exists("%s.jade" % node.path):
             src = open("%s.jade" % node.path, 'r').read()
         else:
-            raise Exception("Include path doesn't exists")
+            raise Exception("Include path doesn't exist")
 
         parser = pyjade.parser.Parser(src)
         block = parser.parse()


### PR DESCRIPTION
pyjade already honors Jinja's variable_start_string and variable_end_string options, but not its block_start_string and block_end_string options.  I made the following changes:
1. Add block_start_string and block_end_string fields to Compiler instance from options.
2. Populate above options from Jinja environment.
3. Add command-line options for (block|variable)_(start|end)_string, valid only when --compiler=jinja.
4. Add new Compiler methods named variable and tag, which surround their argument with the variable or block start and end strings.
5. Replace interpolations of variable_start_string and variable_end_string with calls to variable method.
6. Replace "{%" and "%}" literals with calls to tag method.
7. (unrelated) Fix minor grammatical error in exception text in pyjade/ext/html.py.

Tests pass and my local .jade files render as expected.
