### PR TITLE
Don't clobber autoescape in Tornado templates.

### DIFF
--- a/pyjade/ext/tornado/__init__.py
+++ b/pyjade/ext/tornado/__init__.py
@@ -9,25 +9,24 @@ ESCAPE_FUNC = '__pyjade_escape'
 ITER_FUNC = '__pyjade_iter'
 
 class Compiler(_Compiler):
-    def compile_top(self):
-        return '{% autoescape None %}'
+
     def visitCodeBlock(self,block):
         self.buffer('{%% block %s %%}'%block.name)
-        if block.mode=='append': self.buffer('{{super()}}')
+        if block.mode=='append': self.buffer('{% raw super() %}')
         self.visitBlock(block)
-        if block.mode=='prepend': self.buffer('{{super()}}')
+        if block.mode=='prepend': self.buffer('{% raw super() %}')
         self.buffer('{% end %}')
 
     # def visitMixin(self,mixin):
-    #     if mixin.block: 
-    #       self.buffer('{%% macro %s(%s) %%}'%(mixin.name,mixin.args)) 
+    #     if mixin.block:
+    #       self.buffer('{%% macro %s(%s) %%}'%(mixin.name,mixin.args))
     #       self.visitBlock(mixin.block)
     #       self.buffer('{% end %}')
     #     else:
-    #       self.buffer('{{%s(%s)}}'%(mixin.name,mixin.args))
+    #       self.buffer('{%% raw %s(%s)} %%}'%(mixin.name,mixin.args))
 
     def interpolate(self, text, escape=True):
-        return self._interpolate(text,lambda x:'{{%s(%s)}}' % (ESCAPE_FUNC, x))
+        return self._interpolate(text,lambda x:'{%% raw %s(%s) %%}' % (ESCAPE_FUNC, x))
 
     def visitMixin(self,mixin):
         raise CurrentlyNotSupported('mixin')
@@ -39,7 +38,10 @@ class Compiler(_Compiler):
         if code.buffer:
             val = code.val.lstrip()
             val = self.var_processor(val)
-            self.buf.append((('{{%s(%%s)}}'%ESCAPE_FUNC) if code.escape else '{{%s}}')%val)
+            if code.escape:
+                self.buf.append('{%% raw %s(%s) %%}' % (ESCAPE_FUNC, val))
+            else:
+                self.buf.append('{%% raw %s %%}' % val)
         else:
             self.buf.append('{%% %s %%}'%code.val)
 
@@ -52,7 +54,7 @@ class Compiler(_Compiler):
               codeTag = code.val.strip().split(' ',1)[0]
               if codeTag in self.autocloseCode:
                   self.buf.append('{%% end%s %%}'%codeTag)
- 
+
     def visitEach(self,each):
         self.buf.append('{%% for %s in %s(%s,%s) %%}'%(','.join(each.keys),ITER_FUNC,each.obj,len(each.keys)))
         self.visit(each.block)
@@ -73,14 +75,14 @@ class Compiler(_Compiler):
         if conditional.type in ['if','unless']: self.buf.append('{% end %}')
 
     def attributes(self,attrs):
-        return "{{%s(%s)}}"%(ATTRS_FUNC,attrs)
+        return "{%% raw %s(%s) %%}" % (ATTRS_FUNC, attrs)
 
 class Template(tornado.template.Template):
     def __init__(self, template_string, name="<string>", *args,**kwargs):
         is_jade = name.endswith(".jade")
         if is_jade:
             template_string = process(template_string,filename=name,compiler=Compiler)
-            
+
         super(Template, self).__init__(template_string, name, *args,**kwargs)
         if is_jade:
             self.namespace.update(


### PR DESCRIPTION
In order to prevent double escaping, the tornado extension disables the
tornado autoescape mechanism that is automatically applied to values in
`{{ }}` expressions. This means that jade templates that make use of 
`{{}}` in addition to jade's built in variable interpolation don't
escape values as one might expect.

This commit replaces the Tornado adapter's use of `{{ }}` with 
`{% raw %}` which prevents double escaping in the same manner and leaves
the user's autoescape setting in tact.