### PR TITLE
increment version number to 3.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup,find_packages
 
 setup(name='pyjade',
-      version='3.1.0',
+      version='3.2.0',
       download_url='git@github.com:syrusakbary/pyjade.git',
       packages=find_packages(),
       author='Syrus Akbary',


### PR DESCRIPTION
I think the version number should be updated, as there have been a few changes since 3.1.0. Not sure if a minor or patch version increment is needed, but I would argue for a minor version bump as at least for the combination with pyramid this is the difference between doesn't work at all, and works fine
