### PR TITLE
Use django's escape when using django templates

### DIFF
--- a/pyjade/ext/django/templatetags.py
+++ b/pyjade/ext/django/templatetags.py
@@ -14,6 +14,7 @@ try:
 except ImportError: # Django < 1.8
     from django.template import FilterExpression
 from django.template.loader import get_template
+from django.utils.html import escape
 import six
 
 from pyjade.runtime import iteration
@@ -37,12 +38,13 @@ class Evaluator(template.Node):
   def render(self, context):
     '''Evaluates the code in the page and returns the result'''
     modules = {
-      'pyjade': __import__('pyjade')
+      'pyjade': __import__('pyjade'),
+      'escape': escape,
     }
     context['false'] = False
     context['true'] = True
     try:
-        return six.text_type(eval('pyjade.runtime.attrs(%s)'%self.code,modules,context))
+        return six.text_type(eval('pyjade.runtime.attrs(%s, escape=escape)'%self.code,modules,context))
     except NameError:
         return ''
 

--- a/pyjade/runtime.py
+++ b/pyjade/runtime.py
@@ -47,7 +47,7 @@ def escape(s):
         .replace('"', '&#34;')
     )
 
-def attrs (attrs=[],terse=False, undefined=None):
+def attrs (attrs=[],terse=False, undefined=None, escape=escape):
     buf = []
     if bool(attrs):
         buf.append(u'')


### PR DESCRIPTION
Using `pyjade.runtime.escape` is fine in most situations, but when dealing with `django`-specific things, like lazy objects, or safe strings, `pyjade.runtime.escape` treats them as arbitrary objects, calling `str` on them.

For safe strings, this means they get escaped again. For lazy objects, it means they get forcefully converted into `str` even if they are `unicode` strings.
