### PR TITLE
Tag interpolation

### DIFF
--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -184,7 +184,10 @@ class Compiler(object):
                     raise Exception('%s is self closing and should not have content.' % name)
                 closed = True
 
-        self.buffer('<%s' % name)
+        if tag.buffer:
+            self.buffer('<' + self.interpolate(name))
+        else:
+            self.buffer('<%s' % name)
         self.visitAttributes(tag.attrs)
         self.buffer('/>' if not self.terse and closed else '>')
 
@@ -200,7 +203,10 @@ class Compiler(object):
             if self.pp and not name in self.inlineTags and not textOnly:
                 self.buffer('\n' + '  ' * (self.indents-1))
 
-            self.buffer('</%s>' % name)
+            if tag.buffer:
+                self.buffer('</' + self.interpolate(name) + '>')
+            else:
+                self.buffer('</%s>' % name)
         self.indents -= 1
 
     def visitFilter(self,filter):

--- a/pyjade/compiler.py
+++ b/pyjade/compiler.py
@@ -166,6 +166,8 @@ class Compiler(object):
     def visitTag(self,tag):
         self.indents += 1
         name = tag.name
+        if tag.buffer:
+            name = self.interpolate(name, escape=False)
         if not self.hasCompiledTag:
             if not self.hasCompiledDoctype and 'html' == name:
                 self.visitDoctype()
@@ -184,10 +186,7 @@ class Compiler(object):
                     raise Exception('%s is self closing and should not have content.' % name)
                 closed = True
 
-        if tag.buffer:
-            self.buffer('<' + self.interpolate(name))
-        else:
-            self.buffer('<%s' % name)
+        self.buffer('<%s' % name)
         self.visitAttributes(tag.attrs)
         self.buffer('/>' if not self.terse and closed else '>')
 
@@ -203,10 +202,7 @@ class Compiler(object):
             if self.pp and not name in self.inlineTags and not textOnly:
                 self.buffer('\n' + '  ' * (self.indents-1))
 
-            if tag.buffer:
-                self.buffer('</' + self.interpolate(name) + '>')
-            else:
-                self.buffer('</%s>' % name)
+            self.buffer('</%s>' % name)
         self.indents -= 1
 
     def visitFilter(self,filter):

--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -64,6 +64,8 @@ class Compiler(pyjade.compiler.Compiler):
                 arg_values = self._do_eval(args)
             else:
                 arg_values = []
+            if not isinstance(arg_values, (list, tuple)):
+                arg_values = [arg_values]
             local_context = dict(zip(arg_names, arg_values))
             with local_context_manager(self, local_context):
                 self.visitBlock(mixin.block)

--- a/pyjade/lexer.py
+++ b/pyjade/lexer.py
@@ -56,7 +56,7 @@ def replace_string_brackets(splitted_string):
 class Lexer(object):
     RE_INPUT = re.compile(r'\r\n|\r')
     RE_COMMENT = re.compile(r'^ *\/\/(-)?([^\n]*)')
-    RE_TAG = re.compile(r'^(\w[-:\w]*)')
+    RE_TAG = re.compile(r'^(\w[-:\w]*|#\{.*?\})')
     RE_DOT_BLOCK_START = re.compile(r'^\.\n')
     RE_FILTER = re.compile(r'^:(\w+)')
     RE_DOCTYPE = re.compile(r'^(?:!!!|doctype) *([^\n]+)?')

--- a/pyjade/lexer.py
+++ b/pyjade/lexer.py
@@ -67,7 +67,7 @@ class Lexer(object):
     RE_EXTENDS = re.compile(r'^extends? +([^\n]+)')
     RE_PREPEND = re.compile(r'^prepend +([^\n]+)')
     RE_APPEND = re.compile(r'^append +([^\n]+)')
-    RE_BLOCK = re.compile(r'''^block(( +(?:(prepend|append) +)?([^\n]*))|\n)''')
+    RE_BLOCK = re.compile(r'''^block(( +(?:(prepend|append) +)?([^\n]*))|(?=\n))''')
     RE_YIELD = re.compile(r'^yield *')
     RE_INCLUDE = re.compile(r'^include +([^\n]+)')
     RE_ASSIGNMENT = re.compile(r'^(-\s+var\s+)?(\w+) += *([^;\n]+)( *;? *)')

--- a/pyjade/nodes.py
+++ b/pyjade/nodes.py
@@ -105,7 +105,7 @@ class Literal(Node):
 		self.str = str.replace('\\','\\\\')
 
 class Tag(Node):
-	def __init__(self,name, block=None, inline=False):
+	def __init__(self,name, block=None, inline=False, buffer=False):
 		self.name = name
 		self.textOnly = False
 		self.code = None
@@ -113,6 +113,7 @@ class Tag(Node):
 		self._attrs = []
 		self.inline = inline
 		self.block = block or Block()
+                self.buffer = buffer
 
 	@classmethod
 	def static(self, string, only_remove=False):

--- a/pyjade/nodes.py
+++ b/pyjade/nodes.py
@@ -113,7 +113,7 @@ class Tag(Node):
 		self._attrs = []
 		self.inline = inline
 		self.block = block or Block()
-                self.buffer = buffer
+		self.buffer = buffer
 
 	@classmethod
 	def static(self, string, only_remove=False):

--- a/pyjade/parser.py
+++ b/pyjade/parser.py
@@ -284,7 +284,7 @@ class Parser(object):
                                 (self.filename, self.line()))
 
         tok = self.advance()
-        tag = nodes.Tag(tok.val)
+        tag = nodes.Tag(tok.val, buffer=tok.val[0] == '#')
         tag.inline_level = tok.inline_level
         dot = None
 

--- a/pyjade/testsuite/cases/tag.interpolation.html
+++ b/pyjade/testsuite/cases/tag.interpolation.html
@@ -1,0 +1,10 @@
+<p>value</p>
+<p foo="bar">value</p>
+<psuffix something="something">here</psuffix>
+<ul>
+<li><span><img src="contact" class="icon"/>Contact</span>
+</li>
+
+<li><a href="/contact"><img class="icon"/>Contact</a>
+</li>
+</ul>

--- a/pyjade/testsuite/cases/tag.interpolation.jade
+++ b/pyjade/testsuite/cases/tag.interpolation.jade
@@ -1,0 +1,23 @@
+tag = 'p'
+foo = 'bar'
+
+#{tag} value
+#{tag}(foo='bar') value
+#{tag + 'suffix'}(something) here
+
+mixin item(icon, href)
+  li
+    if href
+      a(href=href)
+        img.icon(src=icon)
+        block
+    else
+      span
+        img.icon(src=icon)
+        block
+
+ul
+  +item('contact')
+    | Contact
+  +item(None, '/contact')
+    | Contact


### PR DESCRIPTION
Tag interpolation [[jade issue](https://github.com/pugjs/jade/issues/657)] [[jade commit](https://github.com/pugjs/jade/commit/6cb7826eb1152efbbab1b13918aa10aa6258dcde)]

``` jade
mixin test(tag)
  #{tag} text

+test('div')
```

Also fix a bug in `ext/html.py`

``` python
def _make_mixin(self, mixin):
    arg_names = [arg.strip() for arg in mixin.args.split(",")]
    def _mixin(self, args):
        if args:
            arg_values = self._do_eval(args)
        else:
            arg_values = []
        if not isinstance(arg_values, (list, tuple)):
            arg_values = [arg_values]
        local_context = dict(zip(arg_names, arg_values))
        with local_context_manager(self, local_context):
            self.visitBlock(mixin.block)
    return _mixin
```

If `arg_values` is a string, then `local_context` will map the parameters into the characters of the string instead of the string value.
