### PR TITLE
Remove the CurrentlyNotImplemented exception

### DIFF
--- a/pyjade/ext/django/compiler.py
+++ b/pyjade/ext/django/compiler.py
@@ -3,7 +3,6 @@ import os
 
 from pyjade import Compiler as _Compiler, Parser, register_filter
 from pyjade.runtime import attrs
-from pyjade.exceptions import CurrentlyNotSupported
 from pyjade.utils import process
 
 from django.conf import settings
@@ -34,7 +33,7 @@ class Compiler(_Compiler):
           self.visitBlock(mixin.block)
           self.buffer('{% end__pyjade_kwacro %}')
         elif mixin.block:
-          raise CurrentlyNotSupported("The mixin blocks are not supported yet.")
+          raise NotImplementedError("The mixin blocks are not supported yet.")
         else:
           self.buffer('{%% __pyjade_usekwacro %s %s %%}'%(mixin.name,mixin.args))
         self.mixing -= 1

--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -87,7 +87,7 @@ class Compiler(pyjade.compiler.Compiler):
         self.visit(block)
 
     def visitExtends(self, node):
-        raise pyjade.exceptions.CurrentlyNotSupported()
+        raise NotImplementedError()
 
     def visitMixin(self, mixin):
         if mixin.block:

--- a/pyjade/ext/tornado/__init__.py
+++ b/pyjade/ext/tornado/__init__.py
@@ -2,7 +2,7 @@ from pyjade import Compiler as _Compiler
 from pyjade.runtime import attrs, escape, iteration
 import tornado.template
 from pyjade.utils import process
-from pyjade.exceptions import CurrentlyNotSupported
+
 
 ATTRS_FUNC = '__pyjade_attrs'
 ESCAPE_FUNC = '__pyjade_escape'
@@ -29,7 +29,7 @@ class Compiler(_Compiler):
         return self._interpolate(text,lambda x:'{%% raw %s(%s) %%}' % (ESCAPE_FUNC, x))
 
     def visitMixin(self,mixin):
-        raise CurrentlyNotSupported('mixin')
+        raise NotImplementedError('mixin')
 
     def visitAssignment(self,assignment):
         self.buffer('{%% set %s = %s %%}'%(assignment.name,assignment.val))

--- a/pyjade/testsuite/test_cases.py
+++ b/pyjade/testsuite/test_cases.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 import pyjade
 import pyjade.ext.html
 from pyjade.utils import process
-from pyjade.exceptions import CurrentlyNotSupported
 import six
 
 from nose import with_setup
@@ -167,7 +166,7 @@ def run_case(case,process):
         print('EXPECTED\n',html_src,len(html_src))
         assert processed_jade==html_src
 
-    except CurrentlyNotSupported:
+    except NotImplementedError:
         pass
 
 exclusions = {


### PR DESCRIPTION
NotImplementedError covers all the cases of CurrentlyNotImplemented, and thus CurrentlyNotImplemented is redundant in terms of the standard library
