### PR TITLE
Re-fix ImproperlyConfigured error when calling from CLI in Django 1.8 (#183)

### DIFF
--- a/pyjade/ext/django/loader.py
+++ b/pyjade/ext/django/loader.py
@@ -33,7 +33,17 @@ except ImportError:  # Django >= 1.9
                 template_name=name,
                 loader=loader,
             )
-    except ImportError:  # Django 1.8.x
+    except ImportError:
+        # Django 1.8.x
+        # In case we are running from the command line, we need to ensure
+        # settings are configured before calling Engine.get_default()
+        from django.conf import settings
+        from django.core.exceptions import ImproperlyConfigured
+        try:
+            settings.TEMPLATES
+        except ImproperlyConfigured:
+            settings.configure()
+
         make_origin = Engine.get_default().make_origin
 
 


### PR DESCRIPTION
March 25th of last year, issue #183 was created and a fix was merged for it.  Then on Nov 7th of last year, #215 was merged.  Unfortunately, that merge removed the code which fixed #183.  I ran into the problem described in #183 and through troubleshooting it, I saw the history I just described and verified that the issue was resolved by re-adding the code.  This pull request re-adds the code along with a comment as to why it's there for some extra safety.
