### PR TITLE
Fix ElseIf for HTML mode

### DIFF
--- a/pyjade/ext/html.py
+++ b/pyjade/ext/html.py
@@ -20,7 +20,7 @@ def process_param(key, value, terse=False):
 TYPE_CODE = {
     'if': operator.truth,
     'unless': operator.not_,
-    'elsif': operator.truth,
+    'elif': operator.truth,
     'else': lambda v: True}
 
 


### PR DESCRIPTION
Previous `elsif` keyword is neither valid for Jade syntax (AFAIK) nor works with `nodes.py` `Conditional` class:
`elsif` is not recognised as "next block" for `if` statement.
