### PR TITLE
Import from `collections.abc` to silence a deprecation warning

### DIFF
--- a/pyjade/runtime.py
+++ b/pyjade/runtime.py
@@ -5,7 +5,7 @@ import six
 from itertools import chain
 
 try:
-    from collections import Mapping as MappingType
+    from collections.abc import Mapping as MappingType
 except ImportError:
     import UserDict
     MappingType = (UserDict.UserDict, UserDict.DictMixin, dict)


### PR DESCRIPTION
`collections.abc` exists in all currently supported python versions (2.7, 3.5+), so the proposed fix shouldn't pose any problem