### PR TITLE
Update jinja.py

### DIFF
--- a/pyjade/ext/jinja.py
+++ b/pyjade/ext/jinja.py
@@ -4,7 +4,7 @@ import pyjade.runtime
 
 from pyjade import Compiler as _Compiler
 from pyjade.runtime import attrs as _attrs, iteration
-from jinja2 import Markup
+from jinja2.utils import markupsafe
 from jinja2.runtime import Undefined
 from pyjade.utils import process
 
@@ -12,7 +12,7 @@ ATTRS_FUNC = '__pyjade_attrs'
 ITER_FUNC = '__pyjade_iter'
 
 def attrs(attrs, terse=False):
-    return Markup(_attrs(attrs, terse, Undefined))
+    return markupsafe.Markup(_attrs(attrs, terse, Undefined))
 
 class Compiler(_Compiler):
 


### PR DESCRIPTION
When I was trying to use this library, I was getting import error here "ImportError: cannot import name 'Markup' from 'jinja2'". After changing to jinja2.utils, it works well.